### PR TITLE
Add mavenCentral repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
     ext.apollo_version = '2.0.2'
     repositories {
         google()
+        mavenCentral()
         jcenter()
         
     }
@@ -23,6 +24,7 @@ buildscript {
 allprojects {
     repositories {
         google()
+        mavenCentral()
         jcenter()
         maven { url "https://jitpack.io" }
     }


### PR DESCRIPTION
As [Jcenter's service ended](https://developer.android.com/studio/build/jcenter-migration), it will no longer serve library artefacts. Project did not compile anymore, that is untill mavenCentral was added.

I did not remove JCenter because, while most of the libraries used in this project have moved to maven central, this one hasn't: https://github.com/syedowaisali/crystal-range-seekbar. The last commit on this repo was on 24 Jan, 2018. I would assume the maintainer lost their interest in maintaining the library, maybe switch to an alternative?